### PR TITLE
Include support for prism line-numbers plugin (#5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 
 		<h3>Via a <code>&lt;pre>&lt;code></code></h3>
 
-		<p>If the primary use case is displaying code, it makes sense to initialize from a <code>&lt;pre>&lt;code></code>, same as the one you"d write for using Prism.
+		<p>If the primary use case is displaying code, it makes sense to initialize from a <code>&lt;pre>&lt;code></code>, same as the one you'd write for using Prism.
 		Just use a class of <code>prism-live</code> on it, and Prism Live will take care of the rest.</p>
 	</section>
 	<section>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,10 @@
 		
 		<h3>Supports line-numbers</h3>
 		<textarea class="prism-live line-numbers language-html fill"></textarea>
+		<!-- Below code tests initialization with a pre element. -->
+		<!-- <pre class="prism-live line-numbers language-js"><code>let foo = bar();
+console.log(foo);</code></pre> -->
+
 
 		<h3>Specific height / CSS editing</h3>
 		<textarea class="prism-live language-css fill" style="--height: 15em"></textarea>

--- a/index.html
+++ b/index.html
@@ -37,10 +37,6 @@
 		
 		<h3>Supports line-numbers</h3>
 		<textarea class="prism-live line-numbers language-html fill"></textarea>
-		<!-- Below code tests initialization with a pre element. -->
-		<!-- <pre class="prism-live line-numbers language-js"><code>let foo = bar();
-console.log(foo);</code></pre> -->
-
 
 		<h3>Specific height / CSS editing</h3>
 		<textarea class="prism-live language-css fill" style="--height: 15em"></textarea>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 	<meta charset="UTF-8">
 	<title>Prism Live: Lightweight, extensible, powerful web-based code editor</title>
 	<link rel="stylesheet" href="https://prismjs.com/themes/prism.css">
+	<link rel="stylesheet" href="https://prismjs.com/plugins/line-numbers/prism-line-numbers.css">
 	<link rel="stylesheet" href="prism-live.css">
 	<link rel="stylesheet" href="style.css">
 	<style>
@@ -11,6 +12,7 @@
 			background: black;
 		}
 	</style>
+	
 	<script>
 
 	</script>
@@ -32,6 +34,9 @@
 
 		<h3>Height grows with code / HTML editing</h3>
 		<textarea class="prism-live language-html fill"></textarea>
+		
+		<h3>Supports line-numbers</h3>
+		<textarea class="prism-live line-numbers language-html fill"></textarea>
 
 		<h3>Specific height / CSS editing</h3>
 		<textarea class="prism-live language-css fill" style="--height: 15em"></textarea>
@@ -67,7 +72,7 @@
 
 		<h3>Via a <code>&lt;pre>&lt;code></code></h3>
 
-		<p>If the primary use case is displaying code, it makes sense to initialize from a <code>&lt;pre>&lt;code></code>, same as the one you'd write for using Prism.
+		<p>If the primary use case is displaying code, it makes sense to initialize from a <code>&lt;pre>&lt;code></code>, same as the one you"d write for using Prism.
 		Just use a class of <code>prism-live</code> on it, and Prism Live will take care of the rest.</p>
 	</section>
 	<section>
@@ -86,10 +91,12 @@
 
 <script src="https://blissfuljs.com/bliss.shy.min.js"></script>
 <script src="https://prismjs.com/prism.js"></script>
+<script src="https://prismjs.com/plugins/line-numbers/prism-line-numbers.js"></script>
 <script src="src/prism-live.js"></script>
 <script src="src/prism-live-markup.js"></script>
 <script src="src/prism-live-css.js"></script>
 <script src="src/prism-live-javascript.js"></script>
 <script src="index.js"></script>
+
 </body>
 </html>

--- a/src/prism-live.js
+++ b/src/prism-live.js
@@ -368,7 +368,7 @@ var _ = Prism.Live = class PrismLive {
 		}
     
 		if (this.textarea.classList.contains('line-numbers')) {
-		    this.textarea.style['padding-left']=cs['padding-left'];
+			this.textarea.style['padding-left']=cs['padding-left'];
 		}
 
 		this.update();

--- a/src/prism-live.js
+++ b/src/prism-live.js
@@ -366,10 +366,9 @@ var _ = Prism.Live = class PrismLive {
 				this.textarea.style[prop] = this.pre.style[prop] = "inherit";
 			}
 		}
-    
-		if (this.textarea.classList.contains('line-numbers')) {
-			this.textarea.style['padding-left']=cs['padding-left'];
-		}
+	
+		// This is primarily for supporting the line-numbers plugin.
+		this.textarea.style['padding-left'] = cs['padding-left'];
 
 		this.update();
 	}

--- a/src/prism-live.js
+++ b/src/prism-live.js
@@ -365,6 +365,11 @@ var _ = Prism.Live = class PrismLive {
 				this.wrapper.style[prop] = cs[prop];
 				this.textarea.style[prop] = this.pre.style[prop] = "inherit";
 			}
+			console.log(prop)
+		}
+    
+		if (this.textarea.classList.contains('line-numbers')) {
+		    this.textarea.style['padding-left']=cs['padding-left'];
 		}
 
 		this.update();

--- a/src/prism-live.js
+++ b/src/prism-live.js
@@ -365,7 +365,6 @@ var _ = Prism.Live = class PrismLive {
 				this.wrapper.style[prop] = cs[prop];
 				this.textarea.style[prop] = this.pre.style[prop] = "inherit";
 			}
-			console.log(prop)
 		}
     
 		if (this.textarea.classList.contains('line-numbers')) {


### PR DESCRIPTION
Prism line-numbers plugin adds padding to the left of the pre tag when enabled, but this padding does not affect the textarea. This causes the text-area and pre tag to become misaligned, and affects the cursor positioning. See issue #5 for more detail.