### PR TITLE
Add spellcheck toggle support.

### DIFF
--- a/src/prism-live.js
+++ b/src/prism-live.js
@@ -193,6 +193,7 @@ var _ = Prism.Live = class PrismLive {
 
 			this.pre.style.height = this.source.style.height || sourceCS.getPropertyValue("--height");
 			this.pre.style.maxHeight = this.source.style.maxHeight || sourceCS.getPropertyValue("--max-height");
+			this.textarea.spellcheck = this.source.spellcheck || sourceCS.getPropertyValue("--spellcheck");
 		});
 
 		this.update();


### PR DESCRIPTION
Allow end users to toggle spellcheck via attribute or style: `spellcheck="true/false"` or `style="--spellcheck: true/false"`.