### PR TITLE
Bugfix: Removed flex to support pre-height

### DIFF
--- a/prism-live.css
+++ b/prism-live.css
@@ -1,8 +1,6 @@
 div.prism-live {
 	position: relative;
 	box-sizing: border-box;
-	display: flex;
-	flex-flow: column;
 }
 
 textarea.prism-live,
@@ -51,7 +49,6 @@ textarea.prism-live {
 	}
 
 pre.prism-live {
-	flex: 1;
 	position: relative;
 	pointer-events: none;
 	overflow: hidden;


### PR DESCRIPTION
Currently the "height" property does not work, as described in bug #10 .
To get this working I removed the flexbox, which seems to be unnecessarily there.
Please verify it does not break anything before merging this solution :)