### PR TITLE
Fix code editor swallowing "(Command) + `" on Safari

### DIFF
--- a/src/prism-live.js
+++ b/src/prism-live.js
@@ -145,7 +145,7 @@ var _ = Prism.Live = class PrismLive {
 						}
 					}
 				}
-				else if (_.pairs[evt.key]) {
+				else if (_.pairs[evt.key] && !evt[superKey]) {
 					var other = _.pairs[evt.key];
 					this.wrapSelection({
 						before: evt.key,


### PR DESCRIPTION
Fixes #37 

On `keydown` events for pairs (like ', ",  (, \`, etc.), the custom handling is preventing default browser handling of the `keydown` event at the end which is necessary for window switching. So fixed the condition to make sure it only happens if `keydown` of such pair characters was not in combination of `keydown` of `superKey` (which is "Cmd" in case of Mac).

> Why this bug is only in safari? Chrome didn't have this problem with "Cmd + \`" shortcut because it doesn't allow JS running in browser to catch "\`" key press event if it was pressed after "Cmd", only "Cmd" is caught. But safari allows JS to catch both - "Cmd" keypress and then "\`" keypress (even when it was pressed in combination).

